### PR TITLE
Capture-avoiding substitution

### DIFF
--- a/packages/kernel/src/ast.ts
+++ b/packages/kernel/src/ast.ts
@@ -285,7 +285,7 @@ export function allFreeVarsInTerm(term: Term): Set<Ident> {
     case "Var":
       return new Set([term.ident]);
     case "Abs":
-      return allFreeVarsInTerm(term.body).difference(new Set([term.idents]));
+      return allFreeVarsInTerm(term.body).difference(new Set(term.idents));
     case "App":
       return term.args.reduce((acc, arg) => acc.union(allFreeVarsInTerm(arg)), allFreeVarsInTerm(term.func));
   }

--- a/packages/kernel/src/ast.ts
+++ b/packages/kernel/src/ast.ts
@@ -331,7 +331,7 @@ export function freeInTerm(term: Term, v: Ident): boolean {
 export function freeInFormula(formula: Formula, v: Ident): boolean {
   switch (formula.tag) {
     case "Pred":
-      return formula.args.some((arg) => freeInTerm(arg, v));
+      return v === formula.ident || formula.args.some((arg) => freeInTerm(arg, v));
     case "Top":
     case "Bottom":
       return false;

--- a/packages/kernel/src/ast.ts
+++ b/packages/kernel/src/ast.ts
@@ -92,6 +92,74 @@ export function formatJudgement(judgement: Judgement): string {
   return `${assms} ⊢ ${concls}`;
 }
 
+export function renameTerm(term: Term, from_to_table: Map<Ident, Ident>): Term {
+  switch (term.tag) {
+    case "Var":
+      return { tag: "Var", ident: from_to_table.get(term.ident) ?? term.ident };
+    case "Abs": {
+      const new_table = new Map(from_to_table);
+      term.idents.forEach((ident) => new_table.delete(ident));
+      return { tag: "Abs", idents: term.idents, body: renameTerm(term.body, new_table) };
+    }
+    case "App":
+      return {
+        tag: "App",
+        func: renameTerm(term.func, from_to_table),
+        args: term.args.map((arg) => renameTerm(arg, from_to_table)),
+      };
+  }
+}
+
+export function renameFormula(formula: Formula, from_to_table: Map<Ident, Ident>): Formula {
+  switch (formula.tag) {
+    case "Pred":
+      return {
+        tag: "Pred",
+        ident: formula.ident,
+        args: formula.args.map((arg) => renameTerm(arg, from_to_table)),
+      };
+    case "Top":
+    case "Bottom":
+      return formula;
+    case "And":
+      return {
+        tag: "And",
+        left: renameFormula(formula.left, from_to_table),
+        right: renameFormula(formula.right, from_to_table),
+      };
+    case "Or":
+      return {
+        tag: "Or",
+        left: renameFormula(formula.left, from_to_table),
+        right: renameFormula(formula.right, from_to_table),
+      };
+    case "Imply":
+      return {
+        tag: "Imply",
+        left: renameFormula(formula.left, from_to_table),
+        right: renameFormula(formula.right, from_to_table),
+      };
+    case "Forall": {
+      const new_table = new Map(from_to_table);
+      new_table.delete(formula.ident);
+      return {
+        tag: "Forall",
+        ident: formula.ident,
+        body: renameFormula(formula.body, new_table),
+      };
+    }
+    case "Exist": {
+      const new_table = new Map(from_to_table);
+      new_table.delete(formula.ident);
+      return {
+        tag: "Exist",
+        ident: formula.ident,
+        body: renameFormula(formula.body, new_table),
+      };
+    }
+  }
+}
+
 export function substTerm(term: Term, v: Ident, target: Term): Term {
   switch (term.tag) {
     case "Var":
@@ -100,6 +168,23 @@ export function substTerm(term: Term, v: Ident, target: Term): Term {
       if (term.idents.includes(v)) {
         return term;
       }
+
+      // TODO: 毎回fvarsInTargetを計算しているので効率が悪い
+      const fvarsInTarget = allFreeVarsInTerm(target);
+      const rename_table = new Map();
+      for (const ident of term.idents) {
+        if (fvarsInTarget.has(ident)) {
+          rename_table.set(ident, freshen(fvarsInTarget, ident));
+        }
+      }
+      if (rename_table.size > 0) {
+        return {
+          tag: "Abs",
+          idents: term.idents.map((ident) => rename_table.get(ident) ?? ident),
+          body: substTerm(renameTerm(term.body, rename_table), v, target),
+        }
+      }
+
       return {
         tag: "Abs",
         idents: term.idents,
@@ -148,25 +233,86 @@ export function substFormula(
         left: substFormula(formula.left, v, target),
         right: substFormula(formula.right, v, target),
       };
-    case "Forall":
+    case "Forall": {
       if (formula.ident === v) {
         return formula;
       }
+
+      // TODO: 毎回fvarsInTargetを計算しているので効率が悪い
+      const fvarsInTarget = allFreeVarsInTerm(target);
+      if (fvarsInTarget.has(formula.ident)) {
+        const new_ident = freshen(fvarsInTarget, formula.ident);
+        return {
+          tag: "Forall",
+          ident: new_ident,
+          body: substFormula(renameFormula(formula, new Map([[formula.ident, new_ident]])), v, target),
+        };
+      }
+
       return {
         tag: "Forall",
         ident: formula.ident,
         body: substFormula(formula.body, v, target),
       };
-    case "Exist":
+    }
+    case "Exist": {
       if (formula.ident === v) {
         return formula;
       }
+
+      // TODO: 毎回fvarsInTargetを計算しているので効率が悪い
+      const fvarsInTarget = allFreeVarsInTerm(target);
+      if (fvarsInTarget.has(formula.ident)) {
+        const new_ident = freshen(fvarsInTarget, formula.ident);
+        return {
+          tag: "Exist",
+          ident: new_ident,
+          body: substFormula(renameFormula(formula, new Map([[formula.ident, new_ident]])), v, target),
+        };
+      }
+
       return {
         tag: "Exist",
         ident: formula.ident,
         body: substFormula(formula.body, v, target),
       };
+    }
   }
+}
+
+export function allFreeVarsInTerm(term: Term): Set<Ident> {
+  switch (term.tag) {
+    case "Var":
+      return new Set([term.ident]);
+    case "Abs":
+      return allFreeVarsInTerm(term.body).difference(new Set([term.idents]));
+    case "App":
+      return term.args.reduce((acc, arg) => acc.union(allFreeVarsInTerm(arg)), allFreeVarsInTerm(term.func));
+  }
+}
+
+export function allFreeVarsInFormula(formula: Formula): Set<Ident> {
+  switch (formula.tag) {
+    case "Pred":
+      return formula.args.reduce((acc, arg) => acc.union(allFreeVarsInTerm(arg)), new Set([formula.ident]));
+    case "Top":
+    case "Bottom":
+      return new Set();
+    case "And":
+    case "Or":
+    case "Imply":
+      return allFreeVarsInFormula(formula.left).union(allFreeVarsInFormula(formula.right));
+    case "Forall":
+    case "Exist":
+      return allFreeVarsInFormula(formula.body).difference(new Set([formula.ident]));
+  }
+}
+
+export function freshen(idents: Set<Ident>, x: Ident): Ident {
+  while (idents.has(x)) {
+    x = `${x}'`;
+  }
+  return x;
 }
 
 export function freeInTerm(term: Term, v: Ident): boolean {

--- a/packages/kernel/tsconfig.json
+++ b/packages/kernel/tsconfig.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "lib": [
       "es2023",
+      "ESNext.Collection",
     ],
     "types": [
       "node"


### PR DESCRIPTION
変数のキャプチャが起こらないように`substTerm`と`substFormula`の定義を変更しました．

## 現状の実装の問題点

以下がmainブランチにある現状の実装です．

https://github.com/lapisla-prover/lapisla-prover/blob/6ea8c33dce7de6563b458c4eba6bae064a23cc14/packages/kernel/src/ast.ts#L95-L170

この実装だと変数のキャプチャが起こる場合があります．例えば $(\lambda y. x)[x := y] = \lambda y. y$ になってしまいます．

## 解決策

ラムダ抽象への代入 $(\lambda x. M)[y := N]$ の際に, $x$ を $N$ 中に自由に出現しないものへとリネームすれば良いです．
以下が形式的な定義です．

```math
(\lambda x. M)[y := N] = \begin{cases}
  \lambda x. M & (x = y) \\
  \lambda w. M[x := w][y := N] & (x \in \text{fvars}(N), w \notin \text{fvars}(N)) \\
  \lambda x. M[y := N] & (\text{otherwise})
\end{cases}
```
