### PR TITLE
カーネルのメインループ作成

### DIFF
--- a/packages/kernel/src/checker.test.ts
+++ b/packages/kernel/src/checker.test.ts
@@ -1,7 +1,15 @@
-import { describe, expect, expectTypeOf, test } from "vitest";
+import { describe, expect, test } from "vitest";
 import { Formula, Judgement, Rule, Term } from "./ast";
-import { judgeMany, judgeOne } from "./checker";
+import {
+  judgeMany,
+  judgeOne,
+  ProofCmd,
+  proofLoop,
+  TopCmd,
+  topLoop,
+} from "./checker";
 import { expectErr, expectOk } from "./test-util";
+import { History } from "./history";
 
 test("∀x.((P(x) ∨ Q())) ⊢ (∀x.(P(x)) ∨ Q()) can be proven", () => {
   const sampleAssms: Formula[] = [
@@ -522,5 +530,92 @@ describe("rules", () => {
       { tag: "Pred", ident: "P2", args: [] },
       { tag: "Pred", ident: "P3", args: [] },
     ]);
+  });
+
+  test("proofLoop", () => {
+    const sampleAssms: Formula[] = [
+      {
+        tag: "Forall",
+        ident: "x",
+        body: {
+          tag: "Or",
+          left: { tag: "Pred", ident: "P", args: [{ tag: "Var", ident: "x" }] },
+          right: { tag: "Pred", ident: "Q", args: [] },
+        },
+      },
+    ];
+
+    const sampleConcls: Formula[] = [
+      {
+        tag: "Or",
+        left: {
+          tag: "Forall",
+          ident: "x",
+          body: { tag: "Pred", ident: "P", args: [{ tag: "Var", ident: "x" }] },
+        },
+        right: { tag: "Pred", ident: "Q", args: [] },
+      },
+    ];
+
+    const initialJudgement: Judgement = {
+      assms: sampleAssms,
+      concls: sampleConcls,
+    };
+    const cmds: ProofCmd[] = [
+      { tag: "Apply", rule: { tag: "CR" } },
+      { tag: "Apply", rule: { tag: "OrR2" } },
+      { tag: "Apply", rule: { tag: "PR", index: 1 } },
+      { tag: "Apply", rule: { tag: "OrR1" } },
+      { tag: "Apply", rule: { tag: "ForallR", ident: "y" } },
+      {
+        tag: "Apply",
+        rule: { tag: "ForallL", term: { tag: "Var", ident: "y" } },
+      },
+      { tag: "Apply", rule: { tag: "OrL" } },
+      { tag: "Apply", rule: { tag: "PR", index: 1 } },
+      { tag: "Apply", rule: { tag: "WR" } },
+      { tag: "Apply", rule: { tag: "I" } },
+      { tag: "Apply", rule: { tag: "WR" } },
+      { tag: "Apply", rule: { tag: "I" } },
+    ];
+    const history = new History([initialJudgement]);
+
+    const loop = proofLoop(history);
+    loop.next(); // 初回のnextは最初のyieldまで進めるため
+    for (const cmd of cmds) {
+      const res = loop.next(cmd);
+      if (res.done) {
+        res.value satisfies never;
+        throw new Error("Unreachable");
+      }
+      expectOk(res.value);
+    }
+    expect(history.isFinished()).toBe(true);
+  });
+
+  test("topLoop", () => {
+    // a ==> a
+    const sampleFormula: Formula = {
+      tag: "Imply",
+      left: { tag: "Pred", ident: "a", args: [] },
+      right: { tag: "Pred", ident: "a", args: [] },
+    };
+    const cmds: TopCmd[] = [
+      { tag: "ThmD", name: "id", formula: sampleFormula },
+      { tag: "Apply", rule: { tag: "ImpR" } },
+      { tag: "Apply", rule: { tag: "I" } },
+      { tag: "Qed" },
+    ];
+
+    const loop = topLoop();
+    loop.next(); // 初回のnextは最初のyieldまで進めるため
+    for (const cmd of cmds) {
+      const res = loop.next(cmd);
+      if (res.done) {
+        res.value satisfies never;
+        throw new Error("Unreachable");
+      }
+      expectOk(res.value);
+    }
   });
 });

--- a/packages/kernel/src/checker.test.ts
+++ b/packages/kernel/src/checker.test.ts
@@ -593,6 +593,83 @@ describe("rules", () => {
     expect(history.isFinished()).toBe(true);
   });
 
+  test("proofLoop", () => {
+    const sampleAssms: Formula[] = [
+      {
+        tag: "Forall",
+        ident: "x",
+        body: {
+          tag: "Or",
+          left: { tag: "Pred", ident: "P", args: [{ tag: "Var", ident: "x" }] },
+          right: { tag: "Pred", ident: "Q", args: [] },
+        },
+      },
+    ];
+
+    const sampleConcls: Formula[] = [
+      {
+        tag: "Or",
+        left: {
+          tag: "Forall",
+          ident: "x",
+          body: { tag: "Pred", ident: "P", args: [{ tag: "Var", ident: "x" }] },
+        },
+        right: { tag: "Pred", ident: "Q", args: [] },
+      },
+    ];
+
+    const initialJudgement: Judgement = {
+      assms: sampleAssms,
+      concls: sampleConcls,
+    };
+    const cmds: ProofCmd[] = [
+      { tag: "Apply", rule: { tag: "CR" } },
+      { tag: "Apply", rule: { tag: "OrR2" } },
+      { tag: "Apply", rule: { tag: "PR", index: 1 } },
+      { tag: "Apply", rule: { tag: "OrR1" } },
+      { tag: "Apply", rule: { tag: "ForallR", ident: "y" } },
+      {
+        tag: "Apply",
+        rule: { tag: "ForallL", term: { tag: "Var", ident: "y" } },
+      },
+      { tag: "Apply", rule: { tag: "OrL" } },
+      { tag: "Apply", rule: { tag: "PR", index: 1 } },
+      { tag: "Apply", rule: { tag: "WR" } },
+      { tag: "Apply", rule: { tag: "I" } },
+      { tag: "Apply", rule: { tag: "WR" } },
+      { tag: "Apply", rule: { tag: "I" } },
+    ];
+    const history = new History([initialJudgement]);
+
+    const loop = proofLoop(history);
+    loop.next(); // 初回のnextは最初のyieldまで進めるため
+    for (const cmd of cmds) {
+      const res = loop.next(cmd);
+      if (res.done) {
+        res.value satisfies never;
+        throw new Error("Unreachable");
+      }
+      expectOk(res.value);
+    }
+    expect(history.isFinished()).toBe(true);
+  });
+
+  test("Undo in proof mode", () => {
+    // a ==> a
+    const sampleFormula: Formula = {
+      tag: "Imply",
+      left: { tag: "Pred", ident: "a", args: [] },
+      right: { tag: "Pred", ident: "a", args: [] },
+    };
+    const initialJudgement: Judgement = { assms: [], concls: [sampleFormula] };
+    const history = new History([initialJudgement]);
+    const ploop = proofLoop(history);
+    ploop.next(); // 初回のnextは最初のyieldまで進めるため
+    ploop.next({ tag: "Apply", rule: { tag: "ImpR" } });
+    ploop.next({ tag: "Undo" });
+    expect(history.top()).toEqual([initialJudgement]);
+  });
+
   test("topLoop", () => {
     // a ==> a
     const sampleFormula: Formula = {
@@ -617,5 +694,25 @@ describe("rules", () => {
       }
       expectOk(res.value);
     }
+  });
+
+  test("Sending ThmD returns Err when in proof mode", () => {
+    // a ==> a
+    const sampleFormula: Formula = {
+      tag: "Imply",
+      left: { tag: "Pred", ident: "a", args: [] },
+      right: { tag: "Pred", ident: "a", args: [] },
+    };
+
+    const loop = topLoop();
+    loop.next(); // 初回のnextは最初のyieldまで進めるため
+    loop.next({ tag: "ThmD", name: "id", formula: sampleFormula });
+    loop.next({ tag: "Apply", rule: { tag: "ImpR" } });
+    const res = loop.next({ tag: "ThmD", name: "id", formula: sampleFormula });
+    if (res.done) {
+      res.value satisfies never;
+      throw new Error("Unreachable");
+    }
+    expectErr(res.value);
   });
 });

--- a/packages/kernel/src/common.ts
+++ b/packages/kernel/src/common.ts
@@ -1,6 +1,8 @@
 export type Result<T, E> = { tag: "Ok"; value: T } | { tag: "Err"; error: E };
 
-export function Ok<T, E>(value: T): Result<T, E> {
+export function Ok<E>(): Result<void, E>;
+export function Ok<T, E>(value: T): Result<T, E>;
+export function Ok<T, E>(value?: T): Result<T, E> {
   return { tag: "Ok", value };
 }
 

--- a/packages/kernel/src/env.ts
+++ b/packages/kernel/src/env.ts
@@ -1,0 +1,19 @@
+import { Formula } from "./ast";
+
+export type Env = {
+  thms: Map<string, Formula>;
+};
+
+export function deepCopyEnv(env: Env): Env {
+  return { thms: new Map(env.thms) };
+}
+
+export function initialEnv(): Env {
+  return { thms: new Map() };
+}
+
+export function insertThm(env: Env, ident: string, formula: Formula): Env {
+  const new_env = deepCopyEnv(env);
+  new_env.thms.set(ident, formula);
+  return new_env;
+}

--- a/packages/kernel/src/history.test.ts
+++ b/packages/kernel/src/history.test.ts
@@ -1,118 +1,112 @@
 import { describe, expect, test } from "vitest";
-import { Formula, Judgement, Rule } from './ast';
-import { judgeMany } from './checker';
-import { History } from './history';
-import { expectErr, expectOk } from './test-util';
+import { Formula, Judgement, Rule } from "./ast";
+import { judgeMany } from "./checker";
+import { ProofHistory } from "./history";
+import { expectErr, expectOk } from "./test-util";
 
 // Head case of `checker.test.ts`
 describe("Basic History Tests", () => {
-    const sampleAssms: Formula[] = [
-        {
-            tag: "Forall",
-            ident: "x",
-            body: {
-                tag: "Or",
-                left: { tag: "Pred", ident: "P", args: [{ tag: "Var", ident: "x" }] },
-                right: { tag: "Pred", ident: "Q", args: [] },
-            },
-        },
-    ];
+  const sampleAssms: Formula[] = [
+    {
+      tag: "Forall",
+      ident: "x",
+      body: {
+        tag: "Or",
+        left: { tag: "Pred", ident: "P", args: [{ tag: "Var", ident: "x" }] },
+        right: { tag: "Pred", ident: "Q", args: [] },
+      },
+    },
+  ];
 
-    const sampleConcls: Formula[] = [
-        {
-            tag: "Or",
-            left: {
-                tag: "Forall",
-                ident: "x",
-                body: { tag: "Pred", ident: "P", args: [{ tag: "Var", ident: "x" }] },
-            },
-            right: { tag: "Pred", ident: "Q", args: [] },
-        },
-    ];
+  const sampleConcls: Formula[] = [
+    {
+      tag: "Or",
+      left: {
+        tag: "Forall",
+        ident: "x",
+        body: { tag: "Pred", ident: "P", args: [{ tag: "Var", ident: "x" }] },
+      },
+      right: { tag: "Pred", ident: "Q", args: [] },
+    },
+  ];
 
-    const initialJudgement: Judgement = {
-        assms: sampleAssms,
-        concls: sampleConcls,
-    };
+  const initialJudgement: Judgement = {
+    assms: sampleAssms,
+    concls: sampleConcls,
+  };
 
+  const rules: Rule[] = [
+    { tag: "CR" },
+    { tag: "OrR2" },
+    { tag: "PR", index: 1 },
+    { tag: "OrR1" },
+    { tag: "ForallR", ident: "y" },
+    { tag: "ForallL", term: { tag: "Var", ident: "y" } },
+    { tag: "OrL" },
+    { tag: "PR", index: 1 },
+    { tag: "WR" },
+    { tag: "I" },
+    { tag: "WR" },
+    { tag: "I" },
+  ];
 
-    const rules: Rule[] = [
-        { tag: "CR" },
-        { tag: "OrR2" },
-        { tag: "PR", index: 1 },
-        { tag: "OrR1" },
-        { tag: "ForallR", ident: "y" },
-        { tag: "ForallL", term: { tag: "Var", ident: "y" } },
-        { tag: "OrL" },
-        { tag: "PR", index: 1 },
-        { tag: "WR" },
-        { tag: "I" },
-        { tag: "WR" },
-        { tag: "I" },
-    ];
+  test("successful application of a rule", () => {
+    const history = new ProofHistory([initialJudgement]);
 
-
-
-    test("successful application of a rule", () => {
-        const history = new History([initialJudgement]);
-
-        for (const rule of rules) {
-            expectOk(history.applyRule(rule));
-        }
-    });
-
-    test("Equivalent to `judgeMany`", () => {
-        const history = new History([initialJudgement]);
-
-        for (const rule of rules) {
-            history.applyRule(rule);
-        }
-
-        const n = rules.length;
-
-        for (let i = n; i >= 1; i--) {
-            const result = judgeMany(rules.slice(0, i), [initialJudgement]);
-            expectOk(result);
-            const historyPop = history.pop();
-            expectOk(historyPop);
-            expect(result.value).toEqual(historyPop.value);
-        }
-    });
-
-    test("Empty pop returns error", () => {
-        const history = new History([initialJudgement]);
-
-        // empty
-        expectErr(history.pop());
-    });
-
-    test("do and undo is identity", () => {
-        const n = rules.length;
-
-        for (let i = 1; i < n; i++) {
-            const history = new History([initialJudgement]);
-
-            for (const rule of rules.slice(0, i)) {
-                expectOk(history.applyRule(rule));
-            }
-
-            const historyTop = history.top();
-
-            // undo
-            expectOk(history.pop());
-            // redo
-            expectOk(history.applyRule(rules[i - 1]));
-
-            expect(history.top()).toEqual(historyTop);
-        }
-    });
-
-    test("failed to apply doesn't throw but returns error", () => {
-        const history = new History([initialJudgement]);
-
-        expectErr(history.applyRule({ tag: "I" }));
+    for (const rule of rules) {
+      expectOk(history.applyRule(rule));
     }
-    );
-}
+  });
 
-);
+  test("Equivalent to `judgeMany`", () => {
+    const history = new ProofHistory([initialJudgement]);
+
+    for (const rule of rules) {
+      history.applyRule(rule);
+    }
+
+    const n = rules.length;
+
+    for (let i = n; i >= 1; i--) {
+      const result = judgeMany(rules.slice(0, i), [initialJudgement]);
+      expectOk(result);
+      const historyPop = history.pop();
+      expectOk(historyPop);
+      expect(result.value).toEqual(historyPop.value);
+    }
+  });
+
+  test("Empty pop returns error", () => {
+    const history = new ProofHistory([initialJudgement]);
+
+    // empty
+    expectErr(history.pop());
+  });
+
+  test("do and undo is identity", () => {
+    const n = rules.length;
+
+    for (let i = 1; i < n; i++) {
+      const history = new ProofHistory([initialJudgement]);
+
+      for (const rule of rules.slice(0, i)) {
+        expectOk(history.applyRule(rule));
+      }
+
+      const historyTop = history.top();
+
+      // undo
+      expectOk(history.pop());
+      // redo
+      expectOk(history.applyRule(rules[i - 1]));
+
+      expect(history.top()).toEqual(historyTop);
+    }
+  });
+
+  test("failed to apply doesn't throw but returns error", () => {
+    const history = new ProofHistory([initialJudgement]);
+
+    expectErr(history.applyRule({ tag: "I" }));
+  });
+});

--- a/packages/kernel/src/history.ts
+++ b/packages/kernel/src/history.ts
@@ -1,44 +1,88 @@
-import { Judgement, Rule } from "./ast";
+import { Formula, Ident, Judgement, Rule } from "./ast";
 import { judgeOne } from "./checker";
 import { Err, Ok, Result } from "./common.ts";
+import { Env as TopEnv, initialEnv, insertThm } from "./env.ts";
 
-export class History {
-    private steps: Judgement[][] = [];
+export class ProofHistory {
+  private steps: Judgement[][] = [];
 
-    constructor(initial: Judgement[]) {
-        this.steps.push(initial);
+  constructor(initial: Judgement[]) {
+    this.steps.push(initial);
+  }
+
+  // Check if all goals are finished.
+  isFinished(): boolean {
+    return this.top().length === 0;
+  }
+
+  // Apply rule for top of stack.
+  //   If application finished successfully,
+  //   new goals are pushed to stack.
+  //   If it's not able to apply,
+  //   return Err and goal (top of stack) is not change.
+  applyRule(rule: Rule): Result<Judgement[], string> {
+    const current = this.top();
+    const result = judgeOne(rule, current);
+    if (result.tag === "Ok") {
+      this.steps.push(result.value);
     }
 
-    // Check if all goals are finished.
-    isFinished(): boolean {
-        return this.top().length === 0;
-    }
+    return result;
+  }
 
-    // Apply rule for top of stack.
-    //   If application finished successfully, 
-    //   new goals are pushed to stack.
-    //   If it's not able to apply, 
-    //   return Err and goal (top of stack) is not change.
-    applyRule(rule: Rule): Result<Judgement[], string> {
-        const current = this.top();
-        const result = judgeOne(rule, current);
-        if (result.tag === "Ok") {
-            this.steps.push(result.value);
-        }
+  // Get current goals (top of stack)
+  top(): Judgement[] {
+    return this.steps[this.steps.length - 1];
+  }
 
-        return result;
+  // Pop current goals
+  pop(): Result<Judgement[], string> {
+    if (this.steps.length <= 1) {
+      return Err("No history to pop.");
     }
+    return Ok(this.steps.pop()!);
+  }
+}
 
-    // Get current goals (top of stack)
-    top(): Judgement[] {
-        return this.steps[this.steps.length - 1];
+export type TopStep =
+  | {
+      tag: "ThmD";
+      name: string;
+      formula: Formula;
+      proofHistory: ProofHistory;
+      env: TopEnv;
     }
+  | { tag: "Other"; env: TopEnv };
 
-    // Pop current goals
-    pop(): Result<Judgement[], string> {
-        if (this.steps.length === 1) {
-            return Err("No history to pop.");
-        }
-        return Ok(this.steps.pop()!);
+export class TopHistory {
+  private steps: TopStep[] = [{ tag: "Other", env: initialEnv() }];
+
+  // Insert theorem to current environment and push it to stack.
+  insertThm(name: Ident, formula: Formula, history: ProofHistory): TopEnv {
+    if (!history.isFinished()) {
+      throw new Error("Proof is not finished.");
     }
+    const new_env = insertThm(this.top().env, name, formula);
+    this.steps.push({
+      tag: "ThmD",
+      name,
+      formula,
+      proofHistory: history,
+      env: new_env,
+    });
+    return new_env;
+  }
+
+  // Get current step (top of stack)
+  top(): TopStep {
+    return this.steps.at(-1);
+  }
+
+  // Pop current step
+  pop(): Result<TopStep, string> {
+    if (this.steps.length <= 1) {
+      throw new Error("No history to pop.");
+    }
+    return Ok(this.steps.pop()!);
+  }
 }


### PR DESCRIPTION
close #37 

- `ThmD`, `Qed`, `Apply`を受け付けるようなループを実装した
- ↑の軽いテストを書いた
- グローバル環境の作成はまだ