### PR TITLE
feat(kernel): support import external package

### DIFF
--- a/apps/web/app/[id]/edit/page.tsx
+++ b/apps/web/app/[id]/edit/page.tsx
@@ -66,13 +66,13 @@ const Edit: FC<EditProps> = ({ params }) => {
 
   const kernel = useKernel();
   const mainEditorRef = useRef<monaco.editor.IStandaloneCodeEditor | null>(
-    null
+    null,
   );
   const goalEditorRef = useRef<monaco.editor.IStandaloneCodeEditor | null>(
-    null
+    null,
   );
   const messageEditorRef = useRef<monaco.editor.IStandaloneCodeEditor | null>(
-    null
+    null,
   );
   const [latestProgram, setLatestProgram] = useState<string>("");
   const [interacter, setInteracter] = useState<EditorInteracter | null>(null);
@@ -85,7 +85,7 @@ const Edit: FC<EditProps> = ({ params }) => {
       messageEditorRef.current
     ) {
       setInteracter(
-        new EditorInteracter(mainEditorRef, goalEditorRef, messageEditorRef)
+        new EditorInteracter(mainEditorRef, goalEditorRef, messageEditorRef),
       );
     }
   }, [mainEditorRef.current, goalEditorRef.current, messageEditorRef.current]);
@@ -104,10 +104,10 @@ const Edit: FC<EditProps> = ({ params }) => {
     if (kernel && interacter) {
       mainEditorRef.current.addCommand(
         monacoInstance.KeyMod.CtrlCmd | monacoInstance.KeyCode.DownArrow,
-        () => {
-          step(kernel, interacter);
+        async () => {
+          await step(kernel, interacter);
           updateEnv();
-        }
+        },
       );
 
       mainEditorRef.current.addCommand(
@@ -115,7 +115,7 @@ const Edit: FC<EditProps> = ({ params }) => {
         () => {
           undo(kernel, interacter, 1);
           updateEnv();
-        }
+        },
       );
     }
   }, [kernel, interacter]);
@@ -127,7 +127,7 @@ const Edit: FC<EditProps> = ({ params }) => {
           `${process.env.NEXT_PUBLIC_API_URL}/me/files/${id}`,
           {
             credentials: "include",
-          }
+          },
         );
         const data = await response.json();
         setVersions([...data.versions]);
@@ -147,7 +147,7 @@ const Edit: FC<EditProps> = ({ params }) => {
             `${process.env.NEXT_PUBLIC_API_URL}/me/files/${id}/${Math.max(...versions).toString()}`,
             {
               credentials: "include",
-            }
+            },
           );
           const data2 = await response2.json();
           console.log(data2);

--- a/apps/web/lib/editorEventHandler.ts
+++ b/apps/web/lib/editorEventHandler.ts
@@ -18,7 +18,6 @@ export type StepResult = {
     somethingExecuted: boolean;
 };
 
-
 export function undoLocation(prev: string, next: string): Location | undefined {
     if (next.startsWith(prev)) {
         return undefined;
@@ -43,8 +42,7 @@ export function undoLocation(prev: string, next: string): Location | undefined {
     return undefined;
 }
 
-
-export function step(kernel: Kernel, interacter: EditorInteracter): Result<StepResult, string> {
+export async function step(kernel: Kernel, interacter: EditorInteracter): Promise<Result<StepResult, string>> {
     if (!interacter) {
         return { tag: "Err", error: "No editor interacter." };
     }
@@ -70,14 +68,14 @@ export function step(kernel: Kernel, interacter: EditorInteracter): Result<StepR
         return { tag: "Ok", value: { somethingExecuted: false } };
     }
 
-    const result = kernel.execute(firstCommand);
+    const result = await kernel.execute(firstCommand);
 
     if (result.tag !== "Ok") {
         interacter.setMessagesEditorContent(
             `Execution Error:\n${result.error} \n at row ${firstCommand.loc.start.line + 1}.`
         );
         return { tag: "Err", error: result.error };
-    } 
+    }
 
     const proofHistory = result.value.proofHistory;
     if (proofHistory) {
@@ -104,10 +102,9 @@ export function undo(kernel: Kernel, interacter: EditorInteracter, steps: number
     interacter.removeGreenHighlight(1);
 }
 
-
-export function executeAll(kernel: Kernel, interacter: EditorInteracter) {
+export async function executeAll(kernel: Kernel, interacter: EditorInteracter) {
     while (true) {
-        const result = step(kernel, interacter);
+        const result = await step(kernel, interacter);
         if (result.tag === "Err") {
             console.log(result.error);
             break;
@@ -130,8 +127,6 @@ export function undoStep(kernel: Kernel, interacter: EditorInteracter) {
 
     interacter.removeGreenHighlight(1);
 }
-
-
 
 export function undoUntil(kernel: Kernel, interacter: EditorInteracter, loc: Location): void {
     while (isAfter(kernel.lastLocation(), loc)) {

--- a/apps/web/lib/userKernel.ts
+++ b/apps/web/lib/userKernel.ts
@@ -1,11 +1,40 @@
 import { useRef } from "react";
 import { Kernel } from "@repo/kernel/kernel";
+import { Err, Ok, Result } from "@repo/kernel/common";
+
+async function fetchFile(userName: string, fileName: string, version: number): Promise<Result<string, string>> {
+  const response = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/files/${userName}/${fileName}/${version}`);
+
+  if (response.ok) {
+    const body = await response.json();
+
+    return Ok(body.content);
+  } else {
+    return Err(`Failed to fetch file "${userName}/${fileName}@${version}": ${response.statusText}`);
+  }
+}
+
+const userNameRegex = "[a-z\\d](?:[a-z\\d]|-(?=[a-z\\d])){0,38}";
+const fileNameRegex = "[a-z\\d](?:[a-z\\d]|-(?=[a-z\\d])){0,38}";
+const versionRegex = "\\d+";
 
 export function useKernel(): Kernel {
   const kernelRef = useRef<Kernel | null>(null);
 
   if (!kernelRef.current) {
-    kernelRef.current = new Kernel();
+    kernelRef.current = new Kernel(async (name: string) => {
+      const match = name.match(`^(${userNameRegex})/(${fileNameRegex})@(${versionRegex})$`);
+
+      if (!match) {
+        return Err(`Invalid package name "${name}"`);
+      }
+
+      const userName = match[1];
+      const fileName = match[2];
+      const version = parseInt(match[3]);
+
+      return fetchFile(userName, fileName, version);
+    });
   }
 
   return kernelRef.current;

--- a/packages/kernel/src/history.ts
+++ b/packages/kernel/src/history.ts
@@ -58,6 +58,7 @@ export type TopStep =
     }
   | { tag: "Constant"; name: string; ty: Type; env: TopEnv }
   | { tag: "Axiom"; name: string; formula: Formula; env: TopEnv }
+  | { tag: "Import"; name: string; env: TopEnv }
   | { tag: "Other"; env: TopEnv };
 
 export class TopHistory {
@@ -90,6 +91,11 @@ export class TopHistory {
   insertAxiom(name: Ident, formula: Formula): TopEnv {
     const new_env = insertThm(this.top().env, name, formula);
     this.steps.push({ tag: "Axiom", name, formula, env: new_env });
+    return new_env;
+  }
+
+  insertImport(name: Ident, new_env: TopEnv): TopEnv {
+    this.steps.push({ tag: "Import", name, env: new_env });
     return new_env;
   }
 

--- a/packages/kernel/src/kernel.ts
+++ b/packages/kernel/src/kernel.ts
@@ -2,22 +2,22 @@
 
 import { Judgement, TopCmd } from "./ast";
 import { KernelState, topLoop } from "./checker";
-import { Result } from "./common";
-import { Env } from "./env";
-import { TopHistory } from "./history";
-import { CmdWithLoc, isAfter, Location, parseProgram, PartialProgram } from "./parser";
+import { Err, Ok, Result } from "./common";
+import { deepCopyEnv, Env, insertConstant, insertThm } from "./env";
+import { TopHistory, TopStep } from "./history";
+import { CmdWithLoc, Location, parseProgram, PartialProgram } from "./parser";
 
 export class Kernel {
-    private tophistory: TopHistory;
-    private lastLoc: Location[];
-    private currentState: KernelState;
+    private tophistory: TopHistory = new TopHistory();
+    private lastLoc: Location[] = [{ line: 0, column: 0 }];
+    private currentState: KernelState = { mode: "DeclareWait" };
     private loop: Generator<Result<KernelState, string>, never, TopCmd>;
+    private pkggeter: (name: string) => string;
 
-    constructor() {
-        this.tophistory = new TopHistory();
+    constructor(pkggeter: (name: string) => string) {
         this.loop = topLoop(this.tophistory);
         this.loop.next(); // initialize
-        this.lastLoc = [{ line: 0, column: 0 }];
+        this.pkggeter = pkggeter;
     }
 
     reset(): void {
@@ -60,16 +60,81 @@ export class Kernel {
         }
     }
 
+    // return the environment after the proof
+    // under the assumption that the proof is correct
+    private collectEnv(
+        src: string
+    ): Result<Env, string> {
+        console.log("Collecting environment from", src);
+        const res = parseProgram(src);
+        if (res.tag === "Err") {
+            return Err(res.error.error.message);
+        }
+
+        let newEnv = deepCopyEnv(this.currentglobalEnv());
+
+        for (const cmd of res.value) {
+            if (cmd.cmd.tag === "Theorem") {
+                newEnv = insertThm(newEnv, cmd.cmd.name, cmd.cmd.formula);
+            } else if (cmd.cmd.tag === "Axiom") {
+                newEnv = insertThm(newEnv, cmd.cmd.name, cmd.cmd.formula);
+            } else if (cmd.cmd.tag === "Constant") {
+                newEnv = insertConstant(newEnv, cmd.cmd.name, cmd.cmd.ty);
+            } else if (cmd.cmd.tag === "Import") {
+                // NOTE: Don't create new command for recursive import!
+                //    In case of undo `import`, all theorems and constants should be removed.
+                //    It means that we need to pack all import for one command.
+                //    So, don't create new command, just collect and merge the environment.
+
+                const childEnv = this.collectEnv(this.pkggeter(cmd.cmd.name));
+
+                if (childEnv.tag === "Err") {
+                    return Err(childEnv.error);
+                }
+
+                // Merge the child environment into the parent environment
+                for (const [key, value] of childEnv.value.thms.entries()) {
+                    newEnv = insertThm(newEnv, key, value);
+                }
+                for (const [key, value] of childEnv.value.types.entries()) {
+                    newEnv = insertConstant(newEnv, key, value);
+                }
+            }
+        }
+
+        return Ok(newEnv);
+    }
+
+
+
     // execute a command
     execute(command: CmdWithLoc): Result<KernelState, string> {
-        const res = this.loop.next(command.cmd);
-        if (res.value.tag == "Ok") {
-            this.currentState = res.value.value;
+        if (command.cmd.tag === "Import") {
+            const importprogram = this.pkggeter(command.cmd.name);
+
+            const newEnv = this.collectEnv(importprogram);
+
+            if (newEnv.tag === "Err") {
+                return { tag: "Err", error: `Import Error: Failed to import ${command.cmd.name} with ${newEnv.error}` };
+            }
+
+            this.tophistory.insertImport(command.cmd.name, newEnv.value);
+
+            this.currentState = { mode: "DeclareWait" };
             this.lastLoc.push(command.loc.end);
+
+            return { tag: "Ok", value: this.currentState };
+
         } else {
-            console.log(res.value.error);
+            const res = this.loop.next(command.cmd);
+            if (res.value.tag == "Ok") {
+                this.currentState = res.value.value;
+                this.lastLoc.push(command.loc.end);
+            } else {
+                console.log(res.value.error);
+            }
+            return res.value;
         }
-        return res.value;
     }
 
     undo(): Result<KernelState, string> {


### PR DESCRIPTION
close #136 

## Overview

To implement this feature, a new `TopStep`: `{ tag: "Import"; name: string; env: TopEnv }`, `pkggeter: (name: string) => string` in the `Kernel` is added

The execution of `import` is highly specific because it requires network operations to fetch code from a registry.

This is why it is implemented at the wrapper level rather than in the core of the kernel. The `import` of a package is considered a functionality of the entire lapisla system, not just the lapisla kernel.

## How to Execute

The `Kernel` requires an implementation of a function that retrieves the actual code from the string argument passed to the `import` command. For example, you can try this PR by writing the following code in `userKernel.ts`:

```ts
import { Kernel } from "@repo/kernel/kernel";
import { useRef } from "react";

export function useKernel(): Kernel {
  const kernelRef = useRef<Kernel | null>(null);

  if (!kernelRef.current) {
    kernelRef.current = new Kernel(
      (name: string) => {
        if (name === "pkg1") {
          return `
          Theorem thm1 P → P
            apply ImpR
            apply I
          qed
          `;
        } else if (name === "pkg2") {
          return `
          import "pkg1"
          Theorem thm2 P → P
            apply ImpR
            apply I
          qed
          `;
        } else if (name === "pkg3") {
          return `
          import "pkg2"
          Theorem thm3 P → P
            apply ImpR
            apply I
          qed
          `;
        }

        return "";
      }
    );
  }

  return kernelRef.current;
}
```

Here, the following command will load the theorem into the environment:

```
import "pkg3"
```

## Remaining Tasks

- [ ] code fetcher (frontend)
- [ ] code fetcher (backend)
