### PR TITLE
feat: ensure file extension for filenames in edit, files, and view pages

### DIFF
--- a/apps/web/app/[id]/edit/page.tsx
+++ b/apps/web/app/[id]/edit/page.tsx
@@ -22,6 +22,7 @@ import {
 import { EditorInteracter } from "@/lib/editorInteracter";
 import { configureMonaco } from "@/lib/monacoConfig";
 import { useKernel } from "@/lib/userKernel";
+import { ensureFileExtension } from "@/utils/ensureFileExtension";
 import { formatRelativeTime } from "@/utils/formatRelativeTime";
 import Editor, { useMonaco } from "@monaco-editor/react";
 import { formatFormula } from "@repo/kernel/ast";
@@ -173,7 +174,7 @@ const Edit: FC<EditProps> = ({ params }) => {
       <div className="w-[80%] p-4 space-y-4">
         <div className="flex justify-between items-end">
           <div className="text-3xl text-gray-700 font-bold g-4 p-4 font-monaco">
-            {account.username}/{id}
+            {account.username}/{ensureFileExtension(id)}
           </div>
           <div className="text-gray-500">
             Last saved {formatRelativeTime(recentSavedTime)}

--- a/apps/web/app/files/page.tsx
+++ b/apps/web/app/files/page.tsx
@@ -20,6 +20,7 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import { useAccount } from "@/context/accountContext";
+import { ensureFileExtension } from "@/utils/ensureFileExtension";
 import { formatRelativeTime } from "@/utils/formatRelativeTime";
 import { Trash, Edit as EditIcon } from "lucide-react";
 import { useEffect, useState } from "react";
@@ -99,7 +100,7 @@ export default function Files() {
                       window.location.href = `/${file.fileName}/edit`;
                     }}
                   >
-                    {file.fileName}
+                    {ensureFileExtension(file.fileName)}
                   </div>
                 </TableCell>
                 <TableCell className="px-4 py-2 text-gray-800 whitespace-nowrap">

--- a/apps/web/app/view/page.tsx
+++ b/apps/web/app/view/page.tsx
@@ -4,6 +4,8 @@ import { FC, use, useEffect, useRef, useState } from "react";
 import * as monaco from "monaco-editor";
 import { getSnapshotInfoFromId } from "@/utils/parseSnapshot";
 import { useSearchParams } from "next/navigation";
+import { configureMonaco } from "@/lib/monacoConfig";
+import { ensureFileExtension } from "../../utils/ensureFileExtension";
 
 interface ViewProps {
   params: Promise<{
@@ -70,7 +72,7 @@ const View: FC<ViewProps> = ({ params }) => {
       <div className="w-[60%] p-4 space-y-4">
         <div className="flex justify-between items-end">
           <div className="text-2xl font-bold">
-            {snapshotInfo.owner}/{snapshotInfo.fileName}
+            {snapshotInfo.owner}/{ensureFileExtension(snapshotInfo.fileName)}
           </div>
         </div>
         <div className="h-0.5 w-full bg-black" />

--- a/apps/web/utils/ensureFileExtension.ts
+++ b/apps/web/utils/ensureFileExtension.ts
@@ -1,0 +1,3 @@
+export function ensureFileExtension(fileName: string): string {
+  return fileName.endsWith('.l') ? fileName : `${fileName}.l`;
+}


### PR DESCRIPTION
close #
実は謙虚に自分でhoge.lのようなファイル名を登録することができない