### PR TITLE
fix(front): infinite API requests due to `useEffect` dependency on `fetchTimelines`

### DIFF
--- a/apps/web/app/timeline/page.tsx
+++ b/apps/web/app/timeline/page.tsx
@@ -35,7 +35,7 @@ export default function Timeline() {
 
   useEffect(() => {
     fetchTimelines()
-  }, [fetchTimelines])
+  }, [])
 
   return (
     <div className="flex">


### PR DESCRIPTION
## Description

remove infinite API requests from timeline.

## Related Issue

If the pull request is related to an issue, please reference the issue here using the following format:

## Checklist

- [x] I have read the CONTRIBUTING.md file.
- [x] I have followed the commit message format.
- [x] I have tested the changes locally.
- [x] I have added tests for the changes (if necessary).
- [x] I have updated the documentation (if necessary).
