### PR TITLE
fix(backend, webui): allow underbar in filename

### DIFF
--- a/apps/backend/src/api/me.service.ts
+++ b/apps/backend/src/api/me.service.ts
@@ -225,7 +225,7 @@ export class MeService {
         throw new HttpException('Unauthorized', 401);
       },
     );
-    const isValidFileName = /^[a-zA-Z0-9-]+$/.test(fileName);
+    const isValidFileName = /^[a-z\d](?:[a-z\d]|-_(?=[a-z\d])){0,38}$/i
     if (!isValidFileName) {
       throw new HttpException('Invalid file name', 400);
     }

--- a/apps/backend/src/api/me.service.ts
+++ b/apps/backend/src/api/me.service.ts
@@ -225,7 +225,7 @@ export class MeService {
         throw new HttpException('Unauthorized', 401);
       },
     );
-    const isValidFileName = /^[a-z\d](?:[a-z\d]|-_(?=[a-z\d])){0,38}$/i
+    const isValidFileName = /^[a-z\d](?:[a-z\d]|-_(?=[a-z\d])){0,38}$/i;
     if (!isValidFileName) {
       throw new HttpException('Invalid file name', 400);
     }

--- a/apps/web/components/newfile.tsx
+++ b/apps/web/components/newfile.tsx
@@ -28,7 +28,7 @@ export function NewFile() {
     fileName: z
       .string()
       .regex(
-        /^[a-z\d](?:[a-z\d]|-(?=[a-z\d])){0,38}$/i,
+        /^[a-z\d](?:[a-z\d]|-_(?=[a-z\d])){0,38}$/i,
         "Invalid file name format"
       ),
   });

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -467,7 +467,7 @@ components:
       pattern: '^[a-z\d](?:[a-z\d]|-(?=[a-z\d])){0,38}@[a-z\d](?:[a-z\d]|-(?=[a-z\d])){0,38}@[0-9]+$'
     User:
       type: string
-      pattern: '/^[a-z\d](?:[a-z\d]|-(?=[a-z\d])){0,38}$/i'
+      pattern: '/^[a-z\d](?:[a-z\d]|-_(?=[a-z\d])){0,38}$/i'
     FileName:
       type: string
       pattern: '/^[a-z\d](?:[a-z\d]|-(?=[a-z\d])){0,38}$/i'


### PR DESCRIPTION
## Description

Allow `_` in filename

## Related Issue

- close #263

## Checklist

- [x] I have read the CONTRIBUTING.md file.
- [x] I have followed the commit message format.
- [x] I have tested the changes locally.
- [x] I have added tests for the changes (if necessary).
- [x] I have updated the documentation (if necessary).
