### PR TITLE
feat(front): make the timeline retroactive

### DIFF
--- a/apps/web/app/timeline/page.tsx
+++ b/apps/web/app/timeline/page.tsx
@@ -6,7 +6,7 @@ import { Button } from "@/components/ui/button"
 import { Card } from "@/components/ui/card"
 import { formatRelativeTime } from "@/utils/formatRelativeTime"
 import { getSnapshotId } from "@/utils/parseSnapshot"
-import { FileIcon, RefreshCcw, Tag } from "lucide-react"
+import { FileIcon, Tag } from "lucide-react"
 import Link from "next/link"
 import { useEffect, useState } from "react"
 
@@ -21,13 +21,19 @@ interface TimelineProps {
 }
 
 export default function Timeline() {
+  const [offset, setOffset] = useState(0)
+  const [limit] = useState(10)
   const [timelines, setTimelines] = useState<TimelineProps[]>([])
 
-  const fetchTimelines = async () => {
+
+  const fetchTimelines = async (newOffset = 0) => {
     try {
-      const response = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/timeline`)
+      const response = await fetch(
+        `${process.env.NEXT_PUBLIC_API_URL}/timeline?offset=${newOffset}&limit=${limit}`
+      );
       const data = await response.json()
-      setTimelines(data)
+      setTimelines((prev) => [...prev, ...data])
+      setOffset(newOffset + limit);
     } catch (error) {
       console.error(error)
     }
@@ -45,10 +51,6 @@ export default function Timeline() {
       <div className="flex-1 p-4 md:p-8 overflow-y-scroll max-h-screen max-w-screen-lg mx-auto">
         <div className="flex justify-between items-center mb-6">
           <h1 className="text-2xl font-semibold text-gray-900 dark:text-gray-100">Timeline</h1>
-          <Button onClick={fetchTimelines} variant="outline" size="sm" className="text-gray-600 dark:text-gray-300">
-            <RefreshCcw className="h-4 w-4 mr-2" />
-            Refresh
-          </Button>
         </div>
         <div className="space-y-6">
           {timelines.map((timeline) => (
@@ -97,6 +99,20 @@ export default function Timeline() {
               </div>
             </Card>
           ))}
+
+          <div className="flex justify-between items-center">
+            {/* load more */}
+            <Button
+              onClick={() => fetchTimelines(offset)}
+              variant="outline"
+              size="sm"
+              disabled={timelines.length < limit}
+              className="mt-4 justify-center"
+            >
+              Load more
+            </Button>
+
+          </div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Description

Make the timeline retroactive.

New button, "Load more" added in bottom of timeline, and clicking on it will bring up the previous files.

<img width="672" alt="image" src="https://github.com/user-attachments/assets/92b0b888-fbaf-4da6-886d-e58fa39cda5d" />


## Related Issue

If the pull request is related to an issue, please reference the issue here using the following format:

- fix #286 

## Checklist

- [x] I have read the CONTRIBUTING.md file.
- [x] I have followed the commit message format.
- [x] I have tested the changes locally.
- [x] I have added tests for the changes (if necessary).
- [x] I have updated the documentation (if necessary).
