### PR TITLE
feat: add beforeunload dialog

### DIFF
--- a/apps/web/components/sidemenu.tsx
+++ b/apps/web/components/sidemenu.tsx
@@ -3,9 +3,8 @@ import { Save } from "@/components/save";
 import { Share } from "@/components/share";
 import { Button } from "@/components/ui/button";
 import { useAccount } from "@/context/accountContext";
-import { Avatar, AvatarFallback, AvatarImage } from "@radix-ui/react-avatar";
+import { Avatar, AvatarImage } from "@radix-ui/react-avatar";
 import { Book, ChartGantt, Folder, Home } from "lucide-react";
-import { useRouter } from "next/navigation";
 
 interface SideMenuProps {
   fileName?: string;
@@ -19,18 +18,17 @@ interface SideMenuProps {
 }
 
 export function SideMenu(props: SideMenuProps) {
-  const router = useRouter();
   const { account } = useAccount();
 
   return (
     <div className="left-0 top-0 h-screen bg-gray-100 w-24 flex flex-col items-center py-4 space-y-4">
-        
+
       {props.enabledFeatures.has("home") && (
         <Button
           variant="ghost"
           size="icon"
           title="Home"
-          onClick={() => router.push("/")}
+          onClick={() => window.open("/", "_blank")}
         >
           <Home className="h-6 w-6" />
         </Button>
@@ -41,7 +39,7 @@ export function SideMenu(props: SideMenuProps) {
           variant="ghost"
           size="icon"
           title="Files"
-          onClick={() => router.push("/files")}
+          onClick={() => window.open("/files", "_blank")}
         >
           <Folder className="h-6 w-6" />
         </Button>
@@ -52,7 +50,7 @@ export function SideMenu(props: SideMenuProps) {
           variant="ghost"
           size="icon"
           title="Timeline"
-          onClick={() => router.push("/timeline")}
+          onClick={() => window.open("/timeline", "_blank")}
         >
           <ChartGantt className="h-6 w-6" />
         </Button>
@@ -66,27 +64,31 @@ export function SideMenu(props: SideMenuProps) {
         </a>
       )}
 
-      {props.enabledFeatures.has("save") && props.fileName && props.content && props.setRecentSavedTime && (
-        <Save
-          fileName={props.fileName}
-          content={props.content}
-          setRecentSavedTime={props.setRecentSavedTime}
-          setNewVersion={props.setNewVersion}
-        />
-      )}
+      {props.enabledFeatures.has("save") &&
+        props.fileName &&
+        props.content &&
+        props.setRecentSavedTime && (
+          <Save
+            fileName={props.fileName}
+            content={props.content}
+            setRecentSavedTime={props.setRecentSavedTime}
+            setNewVersion={props.setNewVersion}
+          />
+        )}
 
-      {props.enabledFeatures.has("share") && props.fileName && props.version !== undefined && (
-        <Share
-          owner={account.username}
-          fileName={props.fileName}
-          version={props.version}
-        />
-      )}
+      {props.enabledFeatures.has("share") &&
+        props.fileName &&
+        props.version !== undefined && (
+          <Share
+            owner={account.username}
+            fileName={props.fileName}
+            version={props.version}
+          />
+        )}
 
       {props.enabledFeatures.has("register") && props.fileName && (
         <Register fileName={props.fileName} />
       )}
-
 
       <Avatar className="h-10 w-10">
         <AvatarImage


### PR DESCRIPTION
## Description

This PR addresses the risk of losing unsaved changes by implementing two key enhancements:
1. Adding a confirmation dialog that warns users about unsaved changes when they attempt to leave the editor page.
2. Updating side menu buttons to open links in a new tab, thus preserving the current editing session.

## Related Issue

- fix #289 

## Checklist

- [x] I have read the CONTRIBUTING.md file.
- [x] I have followed the commit message format.
- [x] I have tested the changes locally.
- [x] I have added tests for the changes (if necessary).
- [x] I have updated the documentation (if necessary).
