### PR TITLE
Add beforeunload dialog  (improvement version of #290)

### DIFF
--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -1,5 +1,6 @@
 import { AccountProvider } from "@/context/accountContext";
 import type { Metadata } from "next";
+import { NavigationGuardProvider } from "next-navigation-guard";
 import localFont from "next/font/local";
 import "./globals.css";
 
@@ -45,7 +46,9 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body className={`${geistSans.variable} ${geistMono.variable}`}>
-        <AccountProvider>{children}</AccountProvider>
+        <NavigationGuardProvider>
+          <AccountProvider>{children}</AccountProvider>
+        </NavigationGuardProvider>
       </body>
     </html>
   );

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -27,6 +27,7 @@
     "monaco-editor": "^0.52.2",
     "neverthrow": "^8.1.1",
     "next": "^15.1.0",
+    "next-navigation-guard": "^0.1.2",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-hook-form": "^7.54.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -235,6 +235,9 @@ importers:
       next:
         specifier: ^15.1.0
         version: 15.1.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      next-navigation-guard:
+        specifier: ^0.1.2
+        version: 0.1.2(next@15.1.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)
       react:
         specifier: ^18.3.1
         version: 18.3.1
@@ -5312,6 +5315,12 @@ packages:
   neverthrow@8.1.1:
     resolution: {integrity: sha512-DpbZ/UDI0B+TxJB1JysXSfi1++3YK2xLBqQLTlRN0b4zxlZ2MoiB+dKKV8dMRzt1fAFjRKDknXOVJgpl+a4Amw==}
     engines: {node: '>=18'}
+
+  next-navigation-guard@0.1.2:
+    resolution: {integrity: sha512-gh+hUMqnI9a/iQ3sxCd7aagQB0NTioe7kj7UJagVfWh+GWfyr4mErlBy2yNZk0VyXebtW86I3cP6lcwraIFhYA==}
+    peerDependencies:
+      next: ^14 || ^15
+      react: ^18.3.1
 
   next-themes@0.4.4:
     resolution: {integrity: sha512-LDQ2qIOJF0VnuVrrMSMLrWGjRMkq+0mpgl6e0juCLqdJ+oo8Q84JRWT6Wh11VDQKkMMe+dVzDKLWs5n87T+PkQ==}
@@ -13208,6 +13217,11 @@ snapshots:
   neverthrow@8.1.1:
     optionalDependencies:
       '@rollup/rollup-linux-x64-gnu': 4.31.0
+
+  next-navigation-guard@0.1.2(next@15.1.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1):
+    dependencies:
+      next: 15.1.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react: 18.3.1
 
   next-themes@0.4.4(react-dom@19.0.0(react@19.0.0))(react@19.0.0):
     dependencies:


### PR DESCRIPTION
## Description

This PR addresses the risk of losing unsaved changes by adding a confirmation dialog that warns users about unsaved changes when they attempt to leave the editor page.
(This is implemented using https://github.com/LayerXcom/next-navigation-guard)

## Related Issue

If the pull request is related to an issue, please reference the issue here using the following format:

- fix #289 

## Checklist

- [x] I have read the CONTRIBUTING.md file.
- [x] I have followed the commit message format.
- [x] I have tested the changes locally.
- [x] I have added tests for the changes (if necessary).
- [x] I have updated the documentation (if necessary).
